### PR TITLE
Message files should always be read as binary (ASCII-8BIT).

### DIFF
--- a/lib/maildir/serializer/base.rb
+++ b/lib/maildir/serializer/base.rb
@@ -10,7 +10,9 @@ class Maildir
     class Base
       # Reads the file at path. Returns the contents of path.
       def load(path)
-        File.read(path)
+        File.open(path,'rb') do |f|
+          f.read
+        end
       end
 
       # Writes data to path. Returns number of bytes written.


### PR DESCRIPTION
File reading with ruby 1.9 will set message string encoding to system default encoding (often UTF-8).
This is a problem has it causes errors when processing message data (eg. with Mailman).
For example Mail.new(message) will end with ArgumentError: invalid byte sequence in UTF-8

This commit simply set the reading encoding to binary witch solves the problem.
