### PR TITLE
Make Maildirs with square brackets work

### DIFF
--- a/lib/maildir.rb
+++ b/lib/maildir.rb
@@ -128,12 +128,20 @@ class Maildir
   protected
   # Returns an array of keys in dir
   def get_dir_listing(dir)
-    search_path = File.join(self.path, dir.to_s, '*')
+    escaped_path = escape_glob_operators(self.path)
+    search_path = File.join(escaped_path, dir.to_s, '*')
     keys = Dir.glob(search_path)
     #  Remove the maildir's path from the keys
     keys.each do |key|
       key.sub!(@path_regexp, "")
     end
+  end
+
+  # escape special patterns that would be matched
+  # by Dir.glob: *, **, ?, [, ], {, }
+  def escape_glob_operators(path)
+    path.gsub(/(\*\*|\*)/) { |m| "\\#{$1}" }.
+         gsub(/([?\[\]\{\}])/) { |m| "\\#{$1}" }
   end
 end
 require 'maildir/unique_name'

--- a/test/test_maildir.rb
+++ b/test/test_maildir.rb
@@ -60,6 +60,16 @@ class TestMaildir < Test::Unit::TestCase
       messages = temp_maildir.list(:cur)
       assert_equal messages, [@message]
     end
+
+    should "work with paths that contain glob characters" do
+      # FakeFS has trouble with directories containing square brackets
+      FakeFS.deactivate!
+      FileUtils.rm_rf("/tmp/maildir [foo]", :secure => true)
+      maildir = Maildir.new("/tmp/maildir [foo]")
+      message = maildir.add("Hello, world")
+      assert_equal [message], maildir.list(:new)
+      FakeFS.activate!
+    end
   end
 
   context "Maildirs with the same path" do


### PR DESCRIPTION
The current released version of maildir fails with directories that contain square braces or other glob characters. This is a problem for Gmail over IMAP, which prefixes its special labels (All Mail, Drafts, Important, etc) with "[Gmail].".

I ran into this bug while using offlineimap to download my gmail account.
