### PR TITLE
fix chronological order

### DIFF
--- a/lib/maildir/unique_name.rb
+++ b/lib/maildir/unique_name.rb
@@ -37,7 +37,7 @@ class Maildir::UniqueName
   # The middle part contains the microsecond, the process id, and a
   # per-process incrementing counter
   def middle
-    "M#{microsecond}P#{process_id}Q#{delivery_count}"
+    "M#{'%06d' % microsecond}P#{process_id}Q#{delivery_count}"
   end
 
   # The right part is the hostname

--- a/test/test_unique_name.rb
+++ b/test/test_unique_name.rb
@@ -30,6 +30,16 @@ class TestUniqueName < Test::Unit::TestCase
       @new_name.send(:instance_variable_set, :@now, @now)
       assert_not_equal @name, @new_name.to_s
     end
+    
+    should "be chronological" do
+      @name1 = Maildir::UniqueName.new
+      @name1.send(:instance_variable_set, :@now, Time.at(0.000009))
+      
+      @name2 = Maildir::UniqueName.new
+      @name2.send(:instance_variable_set, :@now, Time.at(0.100000))
+      
+      assert_operator @name2.to_s, :>, @name1.to_s
+    end
 
   end
 


### PR DESCRIPTION
Current `Maildir#list` returns files in wrong order because of microseconds. They are compared as unformatted strings, not integers.

Here is a small fix for this issue. Dunno what is better:

1) Change files' names for propper ordering (as in pull request):

``` ruby
class Maildir::UniqueName
#...
  def middle
    "M#{'%06d' % microsecond}P#{process_id}Q#{delivery_count}"
  end
#...
end
```

2) Or change the default sorting algorithm in `Maildir#list` to smth like this:

``` ruby
keys.sort_by! { |k| k.sub(/^(\d+)\.M(\d+)(.+)$/) { "#{$1}.M#{'%06d' % $2.to_i}#{$3}" } }
```
