### PR TITLE
Use HTTPS to fetch gems more securely.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
-


### PR DESCRIPTION
Update the Gemfile to use HTTPS instead of HTTP as the gem source to
prevent man-in-the-middle attacks.
