### PR TITLE
Add support for Ruby gemset.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+maildir


### PR DESCRIPTION
- Enable @maildir gemset when working with the maildir source.
- Useful for environments that support gemsets (e.g. RVM).
- Appears to be successfully ignored by Ruby environments without gemset
  support.
