### PR TITLE
Save and resture the global serializer state

### DIFF
--- a/test/test_serializers.rb
+++ b/test/test_serializers.rb
@@ -17,6 +17,7 @@ class TestSerializers < Minitest::Test
     # NB: dumper.object_id makes test names unique
     context "A message serialized with #{klass} (#{dumper.object_id})" do
       setup do
+        @original_serializer = ::Maildir::Message.serializer
         FakeFS::FileSystem.clear
         @data = case klass.new
         when Maildir::Serializer::Mail
@@ -33,6 +34,10 @@ class TestSerializers < Minitest::Test
         # Set the message serializer
         Maildir::Message.serializer = klass.new
         @message = temp_maildir.add(@data)
+      end
+
+      teardown do
+        Maildir::Message.serializer = @original_serializer
       end
 
       should "have the correct data" do


### PR DESCRIPTION
When testing the serializers, save the global state before the
serializer test is run, and restore it after. This fixes an issue where
tests that run after the serializer tests have run are affected by the
default serializer stored in Maildir::Message.serializer.