### PR TITLE
Refactor pull-request #18

### DIFF
--- a/lib/maildir.rb
+++ b/lib/maildir.rb
@@ -14,7 +14,7 @@ class Maildir
   include Comparable
 
   attr_reader :path
-  attr_accessor :serializer
+  attr_writer :serializer
 
   # Default serializer.
   DEFAULT_SERIALIZER = Maildir::Serializer::Base.new.freeze

--- a/lib/maildir.rb
+++ b/lib/maildir.rb
@@ -41,7 +41,7 @@ class Maildir
 
   # Returns own serializer or falls back to default.
   def serializer
-    @serializer || @@serializer
+    @serializer ||= @@serializer
   end
 
   # Compare maildirs by their paths.

--- a/lib/maildir/message.rb
+++ b/lib/maildir/message.rb
@@ -43,6 +43,7 @@ class Maildir::Message
     if key.nil?
       @dir = :tmp
       @unique_name = Maildir::UniqueName.create
+      @info = nil
     else
       parse_key(key)
     end

--- a/lib/maildir/message.rb
+++ b/lib/maildir/message.rb
@@ -41,9 +41,9 @@ class Maildir::Message
   def initialize(maildir, key=nil)
     @maildir = maildir
     if key.nil?
-      @dir = :tmp
+      @dir         = :tmp
+      @info        = nil
       @unique_name = Maildir::UniqueName.create
-      @info = nil
     else
       parse_key(key)
     end

--- a/lib/maildir/unique_name.rb
+++ b/lib/maildir/unique_name.rb
@@ -9,7 +9,8 @@ class Maildir::UniqueName
     # Return a thread-safe increasing counter
     def counter
       COUNTER_MUTEX.synchronize do
-        @counter = @counter.to_i + 1
+        @counter ||= 0
+        @counter = @counter.to_i.succ
       end
     end
 


### PR DESCRIPTION
## Refactoring PR 18
Pull-request #18 had some really good ideas, but I thought some of them could be implemented in a slightly cleaner way or improve on the commit messages, so I did a bit of refactoring. This was mostly successful, but initializing `@info` in *lib/maildir/message.rb* is complicated by the fact that there's a getter/setter *and* an instance variable, so the best way to clean it up is not immediately obvious to me.

@copiousfreetime suggested initializing the instance variable when invoking Maildir::Message#new, which strikes me as a reasonable place to do it&mdash;the canonically correct place, in fact. However, there might be a better way, so I'm putting it out there for commentary. If no one can come up with a better solution, I'd gladly accept the original patch against *lib/maildir/message.rb* as proposed by @copiousfreetime, just so long as it's not entangled with changes in *lib/maildir.rb* as it was in 31c9f57f44b0a3a62a14bc2e872a7b783519795e.

## FakeFS Isn't Warning-Free
Note that fakefs continues to complain about overwritten methods. However, since that's outside the maildir gem, and only a test dependency, it's really a separate issue. I note it here simply for completeness.