### PR TITLE
Remove warning for uninitialized @info

### DIFF
--- a/lib/maildir/message.rb
+++ b/lib/maildir/message.rb
@@ -43,6 +43,7 @@ class Maildir::Message
     if key.nil?
       @dir = :tmp
       @unique_name = Maildir::UniqueName.create
+      @info = nil
     else
       parse_key(key)
     end


### PR DESCRIPTION
Pulling out the initialization of `@info` into its own pull request as requested in #23 